### PR TITLE
toggle read only on reviceProps, if they are changed

### DIFF
--- a/components/Wysiwyg/Wysiwyg.js
+++ b/components/Wysiwyg/Wysiwyg.js
@@ -52,6 +52,9 @@ class Wysiwyg extends React.Component {
       // // Set blocks
       // this.setBlocks({ ...DEFAULT_BLOCKS, ...nextProps.blocks });
     }
+    if (nextProps.readOnly !== this.state.readOnly) {
+      this.setState({ readOnly: nextProps.readOnly });
+    }
   }
 
   // Blocks


### PR DESCRIPTION
Add the possibility to change readOnly in props on the fly, after the wysiwyg is initialized.